### PR TITLE
Validate remote endpoint configuration

### DIFF
--- a/CleanJson.Infrastructure/Http/RemoteJsonSource.cs
+++ b/CleanJson.Infrastructure/Http/RemoteJsonSource.cs
@@ -1,3 +1,4 @@
+using System;
 using CleanJson.Domain.Abstractions;
 using CleanJson.Infrastructure.Options;
 using Microsoft.Extensions.Options;
@@ -14,7 +15,11 @@ public sealed class RemoteJsonSource : IRemoteJsonSource
     public RemoteJsonSource(HttpClient http, IOptions<RemoteJsonOptions> options)
     {
         _http = http;
-        _endpoint = options.Value.Endpoint ?? string.Empty;
+        _endpoint = options.Value.Endpoint;
+        if (string.IsNullOrWhiteSpace(_endpoint))
+        {
+            throw new InvalidOperationException("Remote JSON endpoint is not configured.");
+        }
     }
 
     public async Task<JToken> FetchAsync(CancellationToken ct = default)

--- a/CleanJson.Web/Program.cs
+++ b/CleanJson.Web/Program.cs
@@ -32,8 +32,6 @@ builder.Services.AddHttpClient<IRemoteJsonSource, RemoteJsonSource>();
 builder.Services.AddSingleton<IJsonCleaner, NewtonsoftJsonCleaner>();
 builder.Services.AddScoped<CleanRemoteJsonHandler>();
 
-System.Console.WriteLine("sdfsdfsdfsdfsdf");
-
 // CORS for React dev
 builder.Services.AddCors(o =>
 {


### PR DESCRIPTION
## Summary
- ensure `RemoteJsonSource` fails fast when endpoint is missing
- remove stray console logging from program startup

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689bbfb07f3483219a89ebf387457cf9