### PR TITLE
Add internal test JSON endpoint

### DIFF
--- a/CleanJson.Web/Controllers/TestJsonController.cs
+++ b/CleanJson.Web/Controllers/TestJsonController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json.Linq;
+
+namespace CleanJson.Web.Controllers;
+
+/// <summary>
+/// Provides a static JSON payload for testing without relying on the external Coderbyte service.
+/// </summary>
+[ApiController]
+[Route("api/test-json")]
+public sealed class TestJsonController : ControllerBase
+{
+    /// <summary>
+    /// Returns sample JSON data similar to the Coderbyte challenge.
+    /// </summary>
+    [HttpGet]
+    [Produces("application/json")]
+    public IActionResult Get()
+    {
+        var payload = new JObject
+        {
+            ["name"] = "Robert",
+            ["age"] = 45,
+            ["children"] = new JArray("Sara", "Alex", "Jack"),
+            ["favMovie"] = "N/A",
+            ["favColor"] = "-",
+            ["education"] = new JObject
+            {
+                ["highschool"] = "",
+                ["college"] = "Yale"
+            }
+        };
+
+        return Ok(payload);
+    }
+}

--- a/CleanJson.Web/appsettings.json
+++ b/CleanJson.Web/appsettings.json
@@ -1,6 +1,6 @@
 {
   "RemoteJson": {
-    "Endpoint": "https://coderbyte.com/api/chaIlenges/json/json-cleaning"
+    "Endpoint": "http://localhost:5133/api/test-json"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- Serve static test JSON payload via new `TestJsonController`
- Configure app to call this local endpoint for remote JSON source

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689bcf3b82a88321b9a80e8403c4eab6