### PR TITLE
Force HTTP/1.1 for remote JSON fetch

### DIFF
--- a/CleanJson.Web/Program.cs
+++ b/CleanJson.Web/Program.cs
@@ -4,6 +4,8 @@ using CleanJson.Infrastructure.Cleaning;
 using CleanJson.Infrastructure.Http;
 using CleanJson.Infrastructure.Options;
 using Microsoft.OpenApi.Models;
+using System;
+using System.Net;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,7 +30,14 @@ builder.Services.Configure<RemoteJsonOptions>(
     builder.Configuration.GetSection(RemoteJsonOptions.SectionName));
 
 // DI (DDD)
-builder.Services.AddHttpClient<IRemoteJsonSource, RemoteJsonSource>();
+builder.Services.AddHttpClient<IRemoteJsonSource, RemoteJsonSource>(client =>
+{
+    // Some third-party APIs do not fully support HTTP/2 and may terminate
+    // the response early. Force HTTP/1.1 to avoid "response ended prematurely"
+    // errors when fetching remote JSON content.
+    client.DefaultRequestVersion = new Version(1, 1);
+    client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+});
 builder.Services.AddSingleton<IJsonCleaner, NewtonsoftJsonCleaner>();
 builder.Services.AddScoped<CleanRemoteJsonHandler>();
 


### PR DESCRIPTION
## Summary
- Ensure HttpClient uses HTTP/1.1 to avoid premature response termination when fetching remote JSON

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689bd14867608321831d6b31c2010acc