### PR TITLE
Add language context toggle and NSwag client placeholder

### DIFF
--- a/react-client/src/App.tsx
+++ b/react-client/src/App.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-// After running NSwag generation, this path will exist:
+import React, { useState } from 'react';
 import { CleanJsonClient } from './api/client';
+import { LanguageProvider } from './context/LanguageContext';
+import MainSection from './components/MainSection';
 
 export default function App() {
-  const [data, setData] = React.useState<any>(null);
-  const [error, setError] = React.useState<string | null>(null);
+  const [data, setData] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
 
   async function load() {
     try {
-      // Use the generated client. Adjust base URL to your API port.
       const client = new CleanJsonClient({ baseUrl: 'https://localhost:7133' });
-      const result = await client.clean_Get(); // generated from GET /api/clean
+      const result = await client.clean_Get();
       setData(result);
       setError(null);
     } catch (e: any) {
@@ -19,13 +19,16 @@ export default function App() {
   }
 
   return (
-    <div style={{ fontFamily: 'sans-serif', padding: 24 }}>
-      <h1>CleanJson Client</h1>
-      <button onClick={load}>Fetch & Clean</button>
-      {error && <pre style={{ color: 'crimson' }}>Error: {error}</pre>}
-      {data && (
-        <pre style={{ marginTop: 16 }}>{JSON.stringify(data, null, 2)}</pre>
-      )}
-    </div>
+    <LanguageProvider>
+      <div style={{ fontFamily: 'sans-serif', padding: 24 }}>
+        <h1>CleanJson Client</h1>
+        <button onClick={load}>Fetch &amp; Clean</button>
+        {error && <pre style={{ color: 'crimson' }}>Error: {error}</pre>}
+        {data && (
+          <pre style={{ marginTop: 16 }}>{JSON.stringify(data, null, 2)}</pre>
+        )}
+        <MainSection />
+      </div>
+    </LanguageProvider>
   );
 }

--- a/react-client/src/api/client.ts
+++ b/react-client/src/api/client.ts
@@ -1,0 +1,18 @@
+// This is a placeholder for the NSwag-generated client.
+// In a real setup, run `npm run generate:client` to regenerate this file.
+export class CleanJsonClient {
+  private baseUrl?: string;
+
+  constructor(options?: { baseUrl?: string }) {
+    this.baseUrl = options?.baseUrl;
+  }
+
+  async clean_Get(): Promise<any> {
+    const url = `${this.baseUrl ?? ''}/api/clean`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return response.json();
+  }
+}

--- a/react-client/src/components/MainSection.tsx
+++ b/react-client/src/components/MainSection.tsx
@@ -1,0 +1,21 @@
+import React, { useContext } from 'react';
+import { LanguageContext } from '../context/LanguageContext';
+
+export default function MainSection() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    return null;
+  }
+  const { favoriteLanguage, toggleLanguage } = context;
+
+  return (
+    <div>
+      <p id="favoriteLanguage">
+        favorite programming language: {favoriteLanguage}
+      </p>
+      <button id="changeFavorite" onClick={toggleLanguage}>
+        toggle language
+      </button>
+    </div>
+  );
+}

--- a/react-client/src/context/LanguageContext.tsx
+++ b/react-client/src/context/LanguageContext.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useState, ReactNode } from 'react';
+
+// Define available languages
+const languages = ['JavaScript', 'Python'];
+
+interface LanguageContextValue {
+  favoriteLanguage: string;
+  toggleLanguage: () => void;
+}
+
+export const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [favoriteLanguage, setFavoriteLanguage] = useState<string>(languages[0]);
+
+  const toggleLanguage = () => {
+    setFavoriteLanguage(prev =>
+      prev === languages[0] ? languages[1] : languages[0]
+    );
+  };
+
+  return (
+    <LanguageContext.Provider value={{ favoriteLanguage, toggleLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- Split language toggle into separate context and MainSection component
- Ensure package.json exposes `generate:client` script for NSwag

## Testing
- `npm run build`
- `npm run generate:client` (fails: `dotnet: not found`)


------
https://chatgpt.com/codex/tasks/task_e_689c0de257608321a7b4dc1eb9e89671