### PR TITLE
fix: avoid undefined getBaseUrl

### DIFF
--- a/CleanJson.Web/nswag.json
+++ b/CleanJson.Web/nswag.json
@@ -19,9 +19,7 @@
     "openApiToTypeScriptClient": {
       "className": "CleanJsonClient",
       "template": "Fetch",
-      "httpClass": "Fetch",
       "useAbortSignal": true,
-      "useGetBaseUrlMethod": true,
       "generateClientClasses": true,
       "generateClientInterfaces": false,
       "generateOptionalParameters": true,


### PR DESCRIPTION
## Summary
- drop `useGetBaseUrlMethod` option in NSwag config so generated client doesn't call an undefined helper

## Testing
- `npm run generate:client` *(fails: NSwag CLI exited without generating output, possibly due to missing .NET runtime)*

------
https://chatgpt.com/codex/tasks/task_e_689c66df234883219e500d24e8398a01