### PR TITLE
Fix missing base URL helper and window fallback in API client

### DIFF
--- a/react-client/src/api/client.ts
+++ b/react-client/src/api/client.ts
@@ -13,8 +13,12 @@ export class CleanJsonClient {
     protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
-        this.http = http ? http : window as any;
+        this.http = http ? http : (typeof window !== "undefined" ? window : globalThis) as any;
         this.baseUrl = this.getBaseUrl("", baseUrl);
+    }
+
+    protected getBaseUrl(defaultUrl: string, baseUrl?: string) {
+        return baseUrl && baseUrl.trim().length > 0 ? baseUrl : defaultUrl;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add missing `getBaseUrl` helper in generated API client
- use `globalThis` fallback when `window` is undefined

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689cfac191548321956c3cb59736416a